### PR TITLE
Convert naming scheme in output distance matrix to work with downstream analyses

### DIFF
--- a/q2_sourmash/_compare.py
+++ b/q2_sourmash/_compare.py
@@ -26,7 +26,7 @@ def compare(min_hash_signature:MinHashSigJsonDirFormat, ksize: int, ignore_abund
     # convert similarity to distance
     np_dis = 1 - np_sim
     # read labels into a list -> labels
-    labels = [item.strip() for item in open(label_file)]
+    labels = [os.path.basename(filename).strip().strip('.fastq.gz') for filename in open(label_file)]
     os.remove(np_file)
     os.remove(label_file)
     return skbio.DistanceMatrix(np_dis, labels)


### PR DESCRIPTION
Converted the naming scheme from file path to sample ID using the `MANIFEST` file. Final output now consists of sample ID and distance metric. Did a quick test to ensure that the filename <--> sample id comparisons were the same and it all check out. 

The test also passes. 

You should be able to run the tutorial all the way through the visualization with emperor.