### PR TITLE
MAINT: replace q2-types-genomics with q2-types

### DIFF
--- a/q2_sourmash/_compute.py
+++ b/q2_sourmash/_compute.py
@@ -14,9 +14,9 @@ from typing import Union
 import pandas as pd
 import qiime2.util
 from q2_types.per_sample_sequences import (
-    SingleLanePerSampleSingleEndFastqDirFmt
+    SingleLanePerSampleSingleEndFastqDirFmt,
+    MultiMAGSequencesDirFmt
 )
-from q2_types_genomics.per_sample_data import MultiMAGSequencesDirFmt
 
 from q2_sourmash._format import MinHashSigJsonDirFormat
 

--- a/q2_sourmash/plugin_setup.py
+++ b/q2_sourmash/plugin_setup.py
@@ -9,7 +9,7 @@ import qiime2.util
 from q2_types.distance_matrix import DistanceMatrix
 from q2_types.per_sample_sequences import SequencesWithQuality
 from q2_types.sample_data import SampleData
-from q2_types_genomics.per_sample_data import MAGs
+from q2_types.per_sample_sequences import MAGs
 from qiime2.plugin import Plugin, Citations
 
 from q2_sourmash._compare import compare


### PR DESCRIPTION
This PR updates q2-sourmash to use the types defined in q2-types rather than q2-types-genomics, after their recent move (https://github.com/qiime2/q2-types/pull/309). 