### PR TITLE
CI: add sourmash to conda recipe

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - sphinx
     - alabaster
     - recommonmark
+    - sourmash-minimal
     - sphinxcontrib-napoleon
 
 


### PR DESCRIPTION
This PR adds the missing `sourmash` package to the conda recipe.